### PR TITLE
`turbine`: support `allOf` for entities

### DIFF
--- a/libs/turbine/bin/cli/src/main.rs
+++ b/libs/turbine/bin/cli/src/main.rs
@@ -21,6 +21,7 @@ pub(crate) struct Cli {
 #[error("unable to execute cli command")]
 pub struct Error;
 
+// TODO: init tracing
 fn main() -> Result<(), Error> {
     let cli: Cli = Cli::parse();
 

--- a/libs/turbine/lib/codegen/Cargo.toml
+++ b/libs/turbine/lib/codegen/Cargo.toml
@@ -23,6 +23,7 @@ heck = "0.4.1"
 once_cell = "1.17.1"
 regex = "1.8.1"
 syn = "2.0.15"
+drop_bomb = "0.1.5"
 
 type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "542836" }
 

--- a/libs/turbine/lib/codegen/Cargo.toml
+++ b/libs/turbine/lib/codegen/Cargo.toml
@@ -25,7 +25,7 @@ regex = "1.8.1"
 syn = "2.0.15"
 drop_bomb = "0.1.5"
 
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "542836" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "cdde490" }
 
 [dev-dependencies]
 similar-asserts = "1.4.2"

--- a/libs/turbine/lib/codegen/src/analysis.rs
+++ b/libs/turbine/lib/codegen/src/analysis.rs
@@ -22,12 +22,6 @@ pub(crate) enum AnalysisError {
     CycleMaxIterationCountReached { iterations: usize },
     #[error("Received collection of types is incomplete")]
     IncompleteGraph,
-    #[error("Expected {expected:?}, but received {received:?} (`{url}`)")]
-    ExpectedNodeKind {
-        expected: NodeKind,
-        received: NodeKind,
-        url: VersionedUrl,
-    },
     #[error("While trying to unify types, a cycle has been detected")]
     UnificationCycle,
     #[error("Unable to merge types")]

--- a/libs/turbine/lib/codegen/src/analysis.rs
+++ b/libs/turbine/lib/codegen/src/analysis.rs
@@ -1,5 +1,5 @@
-mod facts;
-mod unify;
+pub(crate) mod facts;
+pub(crate) mod unify;
 
 use std::collections::HashMap;
 

--- a/libs/turbine/lib/codegen/src/analysis.rs
+++ b/libs/turbine/lib/codegen/src/analysis.rs
@@ -28,6 +28,14 @@ pub(crate) enum AnalysisError {
         received: NodeKind,
         url: VersionedUrl,
     },
+    #[error("While trying to unify types, a cycle has been detected")]
+    UnificationCycle,
+    #[error("Unable to merge types")]
+    UnificationMerge,
+    #[error("Unable to convert back from `repr::*Type` to `*Type`")]
+    UnificationConvert,
+    #[error("Unable to convert `repr::*Type` to `serde_json::Value` and back")]
+    UnificationSerde,
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/libs/turbine/lib/codegen/src/analysis.rs
+++ b/libs/turbine/lib/codegen/src/analysis.rs
@@ -28,8 +28,6 @@ pub(crate) enum AnalysisError {
         received: NodeKind,
         url: VersionedUrl,
     },
-    #[error("unable to unify {kind:?} values just yet")]
-    UnsupportedUnification { kind: NodeKind },
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -41,7 +39,7 @@ pub(crate) enum NodeKind {
 }
 
 impl NodeKind {
-    fn from_any(any: &AnyType) -> Self {
+    const fn from_any(any: &AnyType) -> Self {
         match any {
             AnyType::Data(_) => Self::DataType,
             AnyType::Property(_) => Self::PropertyType,

--- a/libs/turbine/lib/codegen/src/analysis/facts.rs
+++ b/libs/turbine/lib/codegen/src/analysis/facts.rs
@@ -2,6 +2,8 @@ use std::collections::HashSet;
 
 use type_system::url::VersionedUrl;
 
+use crate::analysis::unify::LINK_REF;
+
 pub(crate) struct Facts {
     pub(crate) links: HashSet<VersionedUrl>,
 }
@@ -15,5 +17,9 @@ impl Facts {
 
     pub(crate) fn links(&self) -> &HashSet<VersionedUrl> {
         &self.links
+    }
+
+    pub(crate) fn should_skip(&self, url: &VersionedUrl) -> bool {
+        url == LINK_REF.url()
     }
 }

--- a/libs/turbine/lib/codegen/src/analysis/facts.rs
+++ b/libs/turbine/lib/codegen/src/analysis/facts.rs
@@ -7,9 +7,13 @@ pub(crate) struct Facts {
 }
 
 impl Facts {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             links: HashSet::new(),
         }
+    }
+
+    pub(crate) fn links(&self) -> &HashSet<VersionedUrl> {
+        &self.links
     }
 }

--- a/libs/turbine/lib/codegen/src/analysis/facts.rs
+++ b/libs/turbine/lib/codegen/src/analysis/facts.rs
@@ -1,0 +1,15 @@
+use std::collections::HashSet;
+
+use type_system::url::VersionedUrl;
+
+pub(crate) struct Facts {
+    pub(crate) links: HashSet<VersionedUrl>,
+}
+
+impl Facts {
+    pub fn new() -> Self {
+        Self {
+            links: HashSet::new(),
+        }
+    }
+}

--- a/libs/turbine/lib/codegen/src/analysis/unify.rs
+++ b/libs/turbine/lib/codegen/src/analysis/unify.rs
@@ -1,0 +1,158 @@
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+};
+
+use error_stack::{Report, Result};
+use once_cell::sync::Lazy;
+use type_system::{url::VersionedUrl, EntityType, EntityTypeReference};
+
+use crate::{
+    analysis::{facts::Facts, AnalysisError, NodeKind},
+    error::ErrorAccumulator,
+    AnyType,
+};
+
+static LINK_REF: Lazy<EntityTypeReference> = Lazy::new(|| {
+    EntityTypeReference::new(
+        VersionedUrl::from_str(
+            "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1",
+        )
+        .expect("should be valid url"),
+    )
+});
+
+// We cannot handle lifetimes here, because we own the data already, doing so would create a
+// self-referential struct, which is considered a war crime in some states.
+pub(crate) struct UnificationAnalyzer {
+    stack: Vec<VersionedUrl>,
+    cache: HashMap<VersionedUrl, AnyType>,
+    fetch: Option<Box<dyn FnMut(&VersionedUrl) -> Option<AnyType>>>,
+    facts: Facts,
+
+    visited: HashSet<VersionedUrl>,
+    missing: HashSet<VersionedUrl>,
+}
+
+impl UnificationAnalyzer {
+    pub(crate) fn new(values: impl IntoIterator<Item = AnyType>) -> Self {
+        let cache: HashMap<_, _> = values
+            .into_iter()
+            .map(|value| (value.id().clone(), value))
+            .collect();
+
+        let stack = cache.keys().cloned().collect();
+
+        Self {
+            cache,
+            stack,
+            fetch: None,
+            facts: Facts::new(),
+
+            visited: HashSet::new(),
+            missing: HashSet::new(),
+        }
+    }
+
+    pub(crate) fn with_fetch(
+        &mut self,
+        func: impl FnMut(&VersionedUrl) -> Option<AnyType> + 'static,
+    ) {
+        self.fetch = Some(Box::new(func));
+    }
+
+    pub(crate) fn fetch(&mut self, id: &VersionedUrl) -> Result<&AnyType, AnalysisError> {
+        if self.missing.contains(id) {
+            return Err(Report::new(AnalysisError::IncompleteGraph));
+        }
+
+        if let Some(any) = self.cache.get(id) {
+            return Ok(any);
+        }
+
+        let Some(fetch) = &mut self.fetch else {
+            self.missing.insert(id.clone());
+            return Err(Report::new(AnalysisError::IncompleteGraph))
+        };
+
+        let Some(any) = (fetch)(id) else {
+            self.missing.insert(id.clone());
+            return Err(Report::new(AnalysisError::IncompleteGraph))
+        };
+
+        self.stack.push(any.id().clone());
+        Ok(&*self.cache.entry(any.id().clone()).or_insert(any))
+    }
+
+    pub(crate) fn unify_entity(
+        &mut self,
+        id: &VersionedUrl,
+        entity: &mut EntityType,
+    ) -> Result<(), AnalysisError> {
+        let mut errors = ErrorAccumulator::new();
+        let inherits_from = entity.inherits_from();
+
+        let mut stack = inherits_from.all_of().to_vec();
+
+        while let Some(entry) = stack.pop() {
+            let url = entry.url();
+
+            if let Some(ok) = errors.push(self.fetch(url)) {
+                match ok {
+                    AnyType::Entity(entity) => {
+                        if entity.id() == LINK_REF.url() {
+                            self.facts.links.insert(id.clone());
+
+                            continue;
+                        }
+
+                        let properties = entity.properties().clone();
+                        entity.properties();
+
+                        stack.extend(entity.inherits_from().all_of().into_iter().cloned());
+                    }
+                    other => errors.extend_one(Report::new(AnalysisError::ExpectedNodeKind {
+                        expected: NodeKind::EntityType,
+                        received: NodeKind::from_any(other),
+                        url: other.id().clone(),
+                    })),
+                }
+            }
+        }
+
+        errors.into_result()
+    }
+
+    pub(crate) fn unify(&mut self, id: VersionedUrl) -> Result<(), AnalysisError> {
+        if self.visited.contains(&id) {
+            return Ok(());
+        }
+
+        // we already errored out once, don't need to do it all over again
+        if self.missing.contains(&id) {
+            return Ok(());
+        }
+
+        let any = &mut self.cache[&id];
+
+        let result = match any {
+            AnyType::Entity(entity) => self.unify_entity(&id, entity),
+            other => Err(Report::new(AnalysisError::UnsupportedUnification {
+                kind: NodeKind::from_any(other),
+            })),
+        };
+
+        self.visited.insert(id);
+        result
+    }
+
+    pub(crate) fn run(mut self) -> (HashMap<VersionedUrl, AnyType>, Facts) {
+        let mut errors = ErrorAccumulator::new();
+
+        while let Some(id) = self.stack.pop() {
+            errors.push(self.unify(id));
+        }
+
+        (self.cache, self.facts)
+    }
+}

--- a/libs/turbine/lib/codegen/src/analysis/unify.rs
+++ b/libs/turbine/lib/codegen/src/analysis/unify.rs
@@ -146,13 +146,14 @@ impl UnificationAnalyzer {
         result
     }
 
-    pub(crate) fn run(mut self) -> (HashMap<VersionedUrl, AnyType>, Facts) {
+    pub(crate) fn run(mut self) -> Result<(HashMap<VersionedUrl, AnyType>, Facts), AnalysisError> {
         let mut errors = ErrorAccumulator::new();
 
         while let Some(id) = self.stack.pop() {
             errors.push(self.unify(id));
         }
 
-        (self.cache, self.facts)
+        errors.into_result()?;
+        Ok((self.cache, self.facts))
     }
 }

--- a/libs/turbine/lib/codegen/src/analysis/unify.rs
+++ b/libs/turbine/lib/codegen/src/analysis/unify.rs
@@ -9,7 +9,7 @@ use petgraph::{algo::toposort, graph::DiGraph};
 use type_system::{repr, url::VersionedUrl, EntityType, EntityTypeReference};
 
 use crate::{
-    analysis::{facts::Facts, AnalysisError, NodeKind},
+    analysis::{facts::Facts, AnalysisError},
     error::ErrorAccumulator,
     AnyType,
 };
@@ -165,6 +165,7 @@ impl UnificationAnalyzer {
 
         self.cache
             .insert(entity.id().clone(), AnyType::Entity(entity));
+
         Ok(())
     }
 

--- a/libs/turbine/lib/codegen/src/entity.rs
+++ b/libs/turbine/lib/codegen/src/entity.rs
@@ -360,7 +360,7 @@ fn generate_type_url_inherits_from(entity: &EntityType, resolver: &NameResolver)
             Some(generate_absolute_import(&location))
         });
 
-    quote!(type InheritsFrom = (#(<#all_of as TypeUrl>::InheritsFrom,)*);)
+    quote!(type InheritsFrom = (#(<#all_of as TypeUrl>, <#all_of as TypeUrl>::InheritsFrom,)*);)
 }
 
 fn generate_owned(

--- a/libs/turbine/lib/codegen/src/entity.rs
+++ b/libs/turbine/lib/codegen/src/entity.rs
@@ -1,16 +1,14 @@
 use std::{
     collections::{BTreeMap, HashMap},
     ops::Deref,
-    str::FromStr,
 };
 
-use once_cell::sync::Lazy;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::{Token, Visibility};
 use type_system::{
     url::{BaseUrl, VersionedUrl},
-    EntityType, EntityTypeReference,
+    EntityType,
 };
 
 use crate::{

--- a/libs/turbine/lib/codegen/src/entity.rs
+++ b/libs/turbine/lib/codegen/src/entity.rs
@@ -44,15 +44,6 @@ const RESERVED: &[&str] = &[
     "String",
 ];
 
-static LINK_REF: Lazy<EntityTypeReference> = Lazy::new(|| {
-    EntityTypeReference::new(
-        VersionedUrl::from_str(
-            "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1",
-        )
-        .expect("should be valid url"),
-    )
-});
-
 struct State {
     is_link: bool,
     import: Import,

--- a/libs/turbine/lib/codegen/src/entity.rs
+++ b/libs/turbine/lib/codegen/src/entity.rs
@@ -203,6 +203,7 @@ fn generate_properties_convert(
 
 #[allow(clippy::too_many_lines)]
 fn generate_type(
+    entity: &EntityType,
     variant: Variant,
     location: &Location,
     properties: &BTreeMap<&BaseUrl, Property>,
@@ -237,6 +238,8 @@ fn generate_type(
 
         quote!(pub type #alias #lifetime = #name #lifetime;)
     });
+
+    let doc = generate_doc(entity);
 
     let name = Ident::new(&name.value, Span::call_site());
 
@@ -311,6 +314,7 @@ fn generate_type(
             #conversion
         }
 
+        #doc
         #derive
         #[serde(rename_all = "camelCase")]
         pub struct #name #lifetime {
@@ -377,8 +381,7 @@ fn generate_owned(
     let base_url = entity.id().base_url.as_str();
     let version = entity.id().version;
 
-    let doc = generate_doc(entity);
-    let def = generate_type(Variant::Owned, location, properties, state);
+    let def = generate_type(entity, Variant::Owned, location, properties, state);
 
     // we emulate `#(...)?` which doesn't exist, see https://github.com/dtolnay/quote/issues/213
     let link_data: Vec<_> = state
@@ -408,7 +411,6 @@ fn generate_owned(
     let inherits_from = generate_type_url_inherits_from(entity, resolver);
 
     quote! {
-        #doc
         #def
 
         impl TypeUrl for #name {
@@ -485,8 +487,7 @@ fn generate_ref(
     let name = Ident::new(&location.name.value, Span::call_site());
     let name_ref = Ident::new(&location.name_ref.value, Span::call_site());
 
-    let doc = generate_doc(entity);
-    let def = generate_type(Variant::Ref, location, properties, state);
+    let def = generate_type(entity, Variant::Ref, location, properties, state);
 
     let base_url = entity.id().base_url.as_str();
     let version = entity.id().version;
@@ -519,7 +520,6 @@ fn generate_ref(
     let inherits_from = generate_type_url_inherits_from(entity, resolver);
 
     quote! {
-        #doc
         #def
 
         impl TypeUrl for #name_ref<'_> {
@@ -589,8 +589,7 @@ fn generate_mut(
     let name = Ident::new(&location.name.value, Span::call_site());
     let name_mut = Ident::new(&location.name_mut.value, Span::call_site());
 
-    let doc = generate_doc(entity);
-    let def = generate_type(Variant::Mut, location, properties, state);
+    let def = generate_type(entity, Variant::Mut, location, properties, state);
 
     let base_url = entity.id().base_url.as_str();
     let version = entity.id().version;
@@ -623,7 +622,6 @@ fn generate_mut(
     let inherits_from = generate_type_url_inherits_from(entity, resolver);
 
     quote! {
-        #doc
         #def
 
         impl TypeUrl for #name_mut<'_> {

--- a/libs/turbine/lib/codegen/src/entity.rs
+++ b/libs/turbine/lib/codegen/src/entity.rs
@@ -675,11 +675,7 @@ pub(crate) fn generate(entity: &EntityType, resolver: &NameResolver) -> TokenStr
 
     let properties = properties(entity, resolver, &property_names, &locations);
 
-    let is_link = entity
-        .inherits_from()
-        .all_of()
-        .iter()
-        .any(|reference| reference == &*LINK_REF);
+    let is_link = resolver.facts().links().contains(url);
 
     let mut state = State {
         is_link,

--- a/libs/turbine/lib/codegen/src/entity.rs
+++ b/libs/turbine/lib/codegen/src/entity.rs
@@ -360,7 +360,7 @@ fn generate_type_url_inherits_from(entity: &EntityType, resolver: &NameResolver)
             Some(generate_absolute_import(&location))
         });
 
-    quote!(type InheritsFrom = (#(<#all_of as TypeUrl>, <#all_of as TypeUrl>::InheritsFrom,)*);)
+    quote!(type InheritsFrom = (#(#all_of, <#all_of as TypeUrl>::InheritsFrom,)*);)
 }
 
 fn generate_owned(

--- a/libs/turbine/lib/codegen/src/error.rs
+++ b/libs/turbine/lib/codegen/src/error.rs
@@ -1,0 +1,41 @@
+use drop_bomb::DropBomb;
+use error_stack::Report;
+
+pub(crate) struct ErrorAccumulator<C> {
+    inner: Option<Report<C>>,
+    bomb: DropBomb,
+}
+
+impl<C> ErrorAccumulator<C> {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: None,
+            bomb: DropBomb::new(
+                "ErrorAccumulator must be converted into a `Result` using `into_error`",
+            ),
+        }
+    }
+
+    pub(crate) fn push<T>(&mut self, value: Result<T, Report<C>>) -> Option<T> {
+        match value {
+            Ok(ok) => Some(ok),
+            Err(error) => {
+                self.extend_one(error);
+                None
+            }
+        }
+    }
+
+    pub(crate) fn extend_one(&mut self, report: Report<C>) {
+        match &mut self.inner {
+            Some(inner) => inner.extend_one(report),
+            inner => *inner = Some(report),
+        }
+    }
+
+    pub(crate) fn into_result(mut self) -> Result<(), Report<C>> {
+        self.bomb.defuse();
+
+        self.inner.map_or_else(|| Ok(()), Err)
+    }
+}

--- a/libs/turbine/lib/codegen/src/lib.rs
+++ b/libs/turbine/lib/codegen/src/lib.rs
@@ -4,6 +4,7 @@
 mod analysis;
 mod data;
 mod entity;
+mod error;
 mod graph;
 mod name;
 mod property;

--- a/libs/turbine/lib/codegen/src/lib.rs
+++ b/libs/turbine/lib/codegen/src/lib.rs
@@ -12,7 +12,7 @@ mod shared;
 
 use std::{
     cmp::Ordering,
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     hash::{Hash, Hasher},
     path::PathBuf,
 };

--- a/libs/turbine/lib/codegen/src/name.rs
+++ b/libs/turbine/lib/codegen/src/name.rs
@@ -12,7 +12,10 @@ use regex::Regex;
 use reqwest::Url;
 use type_system::url::VersionedUrl;
 
-use crate::{analysis::DependencyAnalyzer, AnyType};
+use crate::{
+    analysis::{facts::Facts, DependencyAnalyzer},
+    AnyType,
+};
 
 #[derive(Debug, Copy, Clone)]
 pub enum ModuleFlavor {
@@ -330,6 +333,7 @@ pub(crate) struct PropertyName(pub(crate) String);
 pub(crate) struct NameResolver<'a> {
     lookup: &'a HashMap<VersionedUrl, AnyType>,
     analyzer: &'a DependencyAnalyzer<'a>,
+    facts: &'a Facts,
 
     overrides: Vec<Override>,
     module: ModuleFlavor,
@@ -340,10 +344,12 @@ impl<'a> NameResolver<'a> {
     pub(crate) const fn new(
         lookup: &'a HashMap<VersionedUrl, AnyType>,
         analyzer: &'a DependencyAnalyzer<'a>,
+        facts: &'a Facts,
     ) -> Self {
         Self {
             lookup,
             analyzer,
+            facts,
 
             overrides: Vec::new(),
             module: ModuleFlavor::ModRs,
@@ -663,6 +669,10 @@ impl<'a> NameResolver<'a> {
 
     pub(crate) const fn analyzer(&self) -> &'a DependencyAnalyzer<'a> {
         self.analyzer
+    }
+
+    pub(crate) fn facts(&self) -> &'a Facts {
+        self.facts
     }
 }
 

--- a/libs/turbine/lib/codegen/src/property.rs
+++ b/libs/turbine/lib/codegen/src/property.rs
@@ -231,6 +231,9 @@ impl<'a> PropertyTypeGenerator<'a> {
             #def
 
             impl TypeUrl for #name {
+                // The RFC for `allOf` on property types is still in draft
+                type InheritsFrom = ();
+
                 const ID: VersionedUrlRef<'static>  = url!(#base_url / v / #version);
             }
 
@@ -280,6 +283,9 @@ impl<'a> PropertyTypeGenerator<'a> {
             #def
 
             impl TypeUrl for #name_ref<'_> {
+                // The RFC for `allOf` on property types is still in draft
+                type InheritsFrom = ();
+
                 const ID: VersionedUrlRef<'static>  = url!(#base_url / v / #version);
             }
 
@@ -328,6 +334,9 @@ impl<'a> PropertyTypeGenerator<'a> {
             #def
 
             impl TypeUrl for #name_mut<'_> {
+                // The RFC for `allOf` on property types is still in draft
+                type InheritsFrom = ();
+
                 const ID: VersionedUrlRef<'static>  = url!(#base_url / v / #version);
             }
 

--- a/libs/turbine/lib/codegen/src/utilities.rs
+++ b/libs/turbine/lib/codegen/src/utilities.rs
@@ -1,0 +1,40 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use type_system::EntityType;
+
+use crate::{name::NameResolver, shared::determine_import_path};
+
+fn generate_find_inherits_from<'a>(
+    entities: impl IntoIterator<Item = &'a EntityType>,
+    resolver: &NameResolver,
+) -> TokenStream {
+    let arms = resolver
+        .locations(entities.into_iter().map(EntityType::id), &[])
+        .into_values()
+        .map(|location| {
+            let path = determine_import_path(&location);
+            let name = location.name.value;
+
+            let ident = quote!(crate #(:: #path)* #name);
+
+            quote!(
+                #ident::ID => #ident::InheritsFrom::resolve().collect()
+            )
+        });
+
+    quote! {
+        pub fn find_inherits_from(url: turbine::VersionedUrlRef) -> alloc::collections::BTreeSet<turbine::VersionedUrlRef<'static>> {
+            match url {
+                #(#arms),*
+                _ => alloc::collections::BTreeSet::new()
+            }
+        }
+    }
+}
+
+pub(crate) fn generate<'a>(
+    entities: impl IntoIterator<Item = &'a EntityType> + Clone,
+    resolver: &NameResolver,
+) -> TokenStream {
+    generate_find_inherits_from(entities, resolver)
+}

--- a/libs/turbine/lib/codegen/src/utilities.rs
+++ b/libs/turbine/lib/codegen/src/utilities.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 use type_system::EntityType;
 
 use crate::{name::NameResolver, shared::determine_import_path};
@@ -13,9 +13,9 @@ fn generate_find_inherits_from<'a>(
         .into_values()
         .map(|location| {
             let path = determine_import_path(&location);
-            let name = location.name.value;
+            let name = format_ident!("{}", location.name.value);
 
-            let ident = quote!(crate #(:: #path)* #name);
+            let ident = quote!(crate #(:: #path)* :: #name);
 
             quote!(
                 #ident::ID => #ident::InheritsFrom::resolve().collect()
@@ -25,7 +25,7 @@ fn generate_find_inherits_from<'a>(
     quote! {
         pub fn find_inherits_from(url: turbine::VersionedUrlRef) -> alloc::collections::BTreeSet<turbine::VersionedUrlRef<'static>> {
             match url {
-                #(#arms),*
+                #(#arms ,)*
                 _ => alloc::collections::BTreeSet::new()
             }
         }

--- a/libs/turbine/lib/codegen/src/utilities.rs
+++ b/libs/turbine/lib/codegen/src/utilities.rs
@@ -18,7 +18,7 @@ fn generate_find_inherits_from<'a>(
             let ident = quote!(crate #(:: #path)* :: #name);
 
             quote!(
-                #ident::ID => #ident::InheritsFrom::resolve().collect()
+                #ident::ID => <#ident as TypeUrl>::InheritsFrom::resolve().collect()
             )
         });
 

--- a/libs/turbine/lib/codegen/tests/snapshots/01-property-type-ref.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/01-property-type-ref.stdout
@@ -10,6 +10,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct CountryCode(pub Text);
 impl TypeUrl for CountryCode {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/countryCode/" / v / 1u32);
 }
@@ -43,6 +45,8 @@ pub type CountryCodeV1 = CountryCode;
 #[derive(Debug, Clone, Serialize)]
 pub struct CountryCodeRef<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for CountryCodeRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/countryCode/" / v / 1u32);
 }
@@ -70,6 +74,8 @@ pub type CountryCodeV1Ref<'a> = CountryCodeRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct CountryCodeMut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for CountryCodeMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/countryCode/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/02-property-type-oneOf-data-type.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/02-property-type-oneOf-data-type.stdout
@@ -15,6 +15,8 @@ pub enum UserId {
     Variant1(Number),
 }
 impl TypeUrl for UserId {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/user-id/" / v / 1u32);
 }
@@ -78,6 +80,8 @@ pub enum UserIdRef<'a> {
     Variant1(<Number as Type>::Ref<'a>),
 }
 impl TypeUrl for UserIdRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/user-id/" / v / 1u32);
 }
@@ -137,6 +141,8 @@ pub enum UserIdMut<'a> {
     Variant1(<Number as Type>::Mut<'a>),
 }
 impl TypeUrl for UserIdMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/user-id/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/03-property-type-object.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/03-property-type-object.stdout
@@ -19,6 +19,8 @@ pub struct FullEmail {
     pub secondary_email: Option<SecondaryEmail>,
 }
 impl TypeUrl for FullEmail {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/fullEmail/" / v / 1u32);
 }
@@ -103,6 +105,8 @@ pub struct FullEmailRef<'a> {
     pub secondary_email: Option<<SecondaryEmail as Type>::Ref<'a>>,
 }
 impl TypeUrl for FullEmailRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/fullEmail/" / v / 1u32);
 }
@@ -171,6 +175,8 @@ pub struct FullEmailMut<'a> {
     pub secondary_email: Option<<SecondaryEmail as Type>::Mut<'a>>,
 }
 impl TypeUrl for FullEmailMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/fullEmail/" / v / 1u32);
 }
@@ -255,6 +261,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct PrimaryEmail(pub Text);
 impl TypeUrl for PrimaryEmail {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/primaryEmail/" / v / 1u32);
 }
@@ -288,6 +296,8 @@ pub type PrimaryEmailV1 = PrimaryEmail;
 #[derive(Debug, Clone, Serialize)]
 pub struct PrimaryEmailRef<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for PrimaryEmailRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/primaryEmail/" / v / 1u32);
 }
@@ -315,6 +325,8 @@ pub type PrimaryEmailV1Ref<'a> = PrimaryEmailRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct PrimaryEmailMut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for PrimaryEmailMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/primaryEmail/" / v / 1u32);
 }
@@ -354,6 +366,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct SecondaryEmail(pub Text);
 impl TypeUrl for SecondaryEmail {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/secondaryEmail/" / v / 1u32);
 }
@@ -387,6 +401,8 @@ pub type SecondaryEmailV1 = SecondaryEmail;
 #[derive(Debug, Clone, Serialize)]
 pub struct SecondaryEmailRef<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for SecondaryEmailRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/secondaryEmail/" / v / 1u32);
 }
@@ -414,6 +430,8 @@ pub type SecondaryEmailV1Ref<'a> = SecondaryEmailRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct SecondaryEmailMut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for SecondaryEmailMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/secondaryEmail/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/04-property-type-array.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/04-property-type-array.stdout
@@ -66,6 +66,8 @@ impl Inner2<'a> {
 #[derive(Debug, Clone, Serialize)]
 pub struct ContrivedProperty(pub Vec<Inner0>);
 impl TypeUrl for ContrivedProperty {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/contrived-property/" / v / 1u32);
 }
@@ -111,6 +113,8 @@ pub type ContrivedPropertyV1 = ContrivedProperty;
 #[derive(Debug, Clone, Serialize)]
 pub struct ContrivedPropertyRef<'a>(pub Vec<Inner1<'a>>);
 impl TypeUrl for ContrivedPropertyRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/contrived-property/" / v / 1u32);
 }
@@ -151,6 +155,8 @@ pub type ContrivedPropertyV1Ref<'a> = ContrivedPropertyRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct ContrivedPropertyMut<'a>(pub Vec<Inner2<'a>>);
 impl TypeUrl for ContrivedPropertyMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/contrived-property/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/05-property-type-oneOf-array.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/05-property-type-oneOf-array.stdout
@@ -70,6 +70,8 @@ pub enum ContrivedProperty {
     Variant1(Vec<Inner0>),
 }
 impl TypeUrl for ContrivedProperty {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/contrived-property/" / v / 1u32);
 }
@@ -151,6 +153,8 @@ pub enum ContrivedPropertyRef<'a> {
     Variant1(Vec<Inner1<'a>>),
 }
 impl TypeUrl for ContrivedPropertyRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/contrived-property/" / v / 1u32);
 }
@@ -221,6 +225,8 @@ pub enum ContrivedPropertyMut<'a> {
     Variant1(Vec<Inner2<'a>>),
 }
 impl TypeUrl for ContrivedPropertyMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/contrived-property/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/06-property-type-self-referential.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/06-property-type-self-referential.stdout
@@ -10,6 +10,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct Email(pub Text);
 impl TypeUrl for Email {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/property-type/email/" / v / 1u32);
 }
@@ -43,6 +45,8 @@ pub type EmailV1 = Email;
 #[derive(Debug, Clone, Serialize)]
 pub struct EmailRef<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for EmailRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/property-type/email/" / v / 1u32);
 }
@@ -70,6 +74,8 @@ pub type EmailV1Ref<'a> = EmailRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct EmailMut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for EmailMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/property-type/email/" / v / 1u32);
 }
@@ -121,6 +127,8 @@ pub struct ContactInformation {
     pub email: Email,
 }
 impl TypeUrl for ContactInformation {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/contact-information/" / v / 1u32);
 }
@@ -204,6 +212,8 @@ pub struct ContactInformationRef<'a> {
     pub email: <Email as Type>::Ref<'a>,
 }
 impl TypeUrl for ContactInformationRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/contact-information/" / v / 1u32);
 }
@@ -278,6 +288,8 @@ pub struct ContactInformationMut<'a> {
     pub email: <Email as Type>::Mut<'a>,
 }
 impl TypeUrl for ContactInformationMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/contact-information/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/07-property-type-object-nested.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/07-property-type-object-nested.stdout
@@ -10,6 +10,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct FavoriteFilm(pub Text);
 impl TypeUrl for FavoriteFilm {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> = url!(
         "https://blockprotocol.org/@blockprotocol/types/property-type/favorite-film/" / v / 1u32
     );
@@ -44,6 +46,8 @@ pub type FavoriteFilmV1 = FavoriteFilm;
 #[derive(Debug, Clone, Serialize)]
 pub struct FavoriteFilmRef<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for FavoriteFilmRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> = url!(
         "https://blockprotocol.org/@blockprotocol/types/property-type/favorite-film/" / v / 1u32
     );
@@ -72,6 +76,8 @@ pub type FavoriteFilmV1Ref<'a> = FavoriteFilmRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct FavoriteFilmMut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for FavoriteFilmMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> = url!(
         "https://blockprotocol.org/@blockprotocol/types/property-type/favorite-film/" / v / 1u32
     );
@@ -112,6 +118,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct FavoriteSong(pub Text);
 impl TypeUrl for FavoriteSong {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> = url!(
         "https://blockprotocol.org/@blockprotocol/types/property-type/favorite-song/" / v / 1u32
     );
@@ -146,6 +154,8 @@ pub type FavoriteSongV1 = FavoriteSong;
 #[derive(Debug, Clone, Serialize)]
 pub struct FavoriteSongRef<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for FavoriteSongRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> = url!(
         "https://blockprotocol.org/@blockprotocol/types/property-type/favorite-song/" / v / 1u32
     );
@@ -174,6 +184,8 @@ pub type FavoriteSongV1Ref<'a> = FavoriteSongRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct FavoriteSongMut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for FavoriteSongMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> = url!(
         "https://blockprotocol.org/@blockprotocol/types/property-type/favorite-song/" / v / 1u32
     );
@@ -214,6 +226,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct Hobby(pub Text);
 impl TypeUrl for Hobby {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/property-type/hobby/" / v / 1u32);
 }
@@ -247,6 +261,8 @@ pub type HobbyV1 = Hobby;
 #[derive(Debug, Clone, Serialize)]
 pub struct HobbyRef<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for HobbyRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/property-type/hobby/" / v / 1u32);
 }
@@ -274,6 +290,8 @@ pub type HobbyV1Ref<'a> = HobbyRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct HobbyMut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for HobbyMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/property-type/hobby/" / v / 1u32);
 }
@@ -330,6 +348,8 @@ pub struct Interests {
     pub hobby: Option<Vec<Hobby>>,
 }
 impl TypeUrl for Interests {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/interests/" / v / 1u32);
 }
@@ -466,6 +486,8 @@ pub struct InterestsRef<'a> {
     pub hobby: Option<Box<[<Hobby as Type>::Ref<'a>]>>,
 }
 impl TypeUrl for InterestsRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/interests/" / v / 1u32);
 }
@@ -581,6 +603,8 @@ pub struct InterestsMut<'a> {
     pub hobby: Option<Vec<<Hobby as Type>::Mut<'a>>>,
 }
 impl TypeUrl for InterestsMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/interests/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/08-entity-type-empty.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/08-entity-type-empty.stdout
@@ -37,6 +37,8 @@ pub struct Country {
 }
 pub type CountryV1 = Country;
 impl TypeUrl for Country {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -104,6 +106,8 @@ pub struct CountryRef<'a> {
 }
 pub type CountryV1Ref<'a> = CountryRef<'a>;
 impl TypeUrl for CountryRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -164,6 +168,8 @@ pub struct CountryMut<'a> {
 }
 pub type CountryV1Mut<'a> = CountryMut<'a>;
 impl TypeUrl for CountryMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/09-entity-type-single-property.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/09-entity-type-single-property.stdout
@@ -57,6 +57,8 @@ pub struct Country {
 }
 pub type CountryV1 = Country;
 impl TypeUrl for Country {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -142,6 +144,8 @@ pub struct CountryRef<'a> {
 }
 pub type CountryV1Ref<'a> = CountryRef<'a>;
 impl TypeUrl for CountryRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -225,6 +229,8 @@ pub struct CountryMut<'a> {
 }
 pub type CountryV1Mut<'a> = CountryMut<'a>;
 impl TypeUrl for CountryMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -279,6 +285,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct Name(pub Text);
 impl TypeUrl for Name {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/name/" / v / 1u32);
 }
@@ -312,6 +320,8 @@ pub type NameV1 = Name;
 #[derive(Debug, Clone, Serialize)]
 pub struct NameRef<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for NameRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/name/" / v / 1u32);
 }
@@ -339,6 +349,8 @@ pub type NameV1Ref<'a> = NameRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct NameMut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for NameMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/name/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/10-entity-type-single-property-optional.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/10-entity-type-single-property-optional.stdout
@@ -60,6 +60,8 @@ pub struct Country {
 }
 pub type CountryV1 = Country;
 impl TypeUrl for Country {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -148,6 +150,8 @@ pub struct CountryRef<'a> {
 }
 pub type CountryV1Ref<'a> = CountryRef<'a>;
 impl TypeUrl for CountryRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -234,6 +238,8 @@ pub struct CountryMut<'a> {
 }
 pub type CountryV1Mut<'a> = CountryMut<'a>;
 impl TypeUrl for CountryMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -288,6 +294,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct Name(pub Text);
 impl TypeUrl for Name {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/name/" / v / 1u32);
 }
@@ -321,6 +329,8 @@ pub type NameV1 = Name;
 #[derive(Debug, Clone, Serialize)]
 pub struct NameRef<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for NameRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/name/" / v / 1u32);
 }
@@ -348,6 +358,8 @@ pub type NameV1Ref<'a> = NameRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct NameMut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for NameMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/name/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/11-entity-type-multiple-properties.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/11-entity-type-multiple-properties.stdout
@@ -71,6 +71,8 @@ pub struct Country {
 }
 pub type CountryV1 = Country;
 impl TypeUrl for Country {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -170,6 +172,8 @@ pub struct CountryRef<'a> {
 }
 pub type CountryV1Ref<'a> = CountryRef<'a>;
 impl TypeUrl for CountryRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -271,6 +275,8 @@ pub struct CountryMut<'a> {
 }
 pub type CountryV1Mut<'a> = CountryMut<'a>;
 impl TypeUrl for CountryMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -327,6 +333,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct CountryCode(pub Text);
 impl TypeUrl for CountryCode {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/countryCode/" / v / 1u32);
 }
@@ -362,6 +370,8 @@ pub type CountryCodeV1 = CountryCode;
 #[derive(Debug, Clone, Serialize)]
 pub struct CountryCodeRef<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for CountryCodeRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/countryCode/" / v / 1u32);
 }
@@ -391,6 +401,8 @@ pub type CountryCodeV1Ref<'a> = CountryCodeRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct CountryCodeMut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for CountryCodeMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/countryCode/" / v / 1u32);
 }
@@ -430,6 +442,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct Name(pub Text);
 impl TypeUrl for Name {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/name/" / v / 1u32);
 }
@@ -463,6 +477,8 @@ pub type NameV1 = Name;
 #[derive(Debug, Clone, Serialize)]
 pub struct NameRef<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for NameRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/name/" / v / 1u32);
 }
@@ -490,6 +506,8 @@ pub type NameV1Ref<'a> = NameRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct NameMut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for NameMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/name/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/12-entity-multiple-versions.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/12-entity-multiple-versions.stdout
@@ -71,6 +71,8 @@ pub struct Country {
 }
 pub type CountryV2 = Country;
 impl TypeUrl for Country {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 2u32);
 }
@@ -170,6 +172,8 @@ pub struct CountryRef<'a> {
 }
 pub type CountryV2Ref<'a> = CountryRef<'a>;
 impl TypeUrl for CountryRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 2u32);
 }
@@ -271,6 +275,8 @@ pub struct CountryMut<'a> {
 }
 pub type CountryV2Mut<'a> = CountryMut<'a>;
 impl TypeUrl for CountryMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 2u32);
 }
@@ -373,6 +379,8 @@ pub struct CountryV1 {
     pub properties: Properties,
 }
 impl TypeUrl for CountryV1 {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -457,6 +465,8 @@ pub struct CountryV1Ref<'a> {
     pub properties: PropertiesRef<'a>,
 }
 impl TypeUrl for CountryV1Ref<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -539,6 +549,8 @@ pub struct CountryV1Mut<'a> {
     pub properties: PropertiesMut<'a>,
 }
 impl TypeUrl for CountryV1Mut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -595,6 +607,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct CountryCode(pub Text);
 impl TypeUrl for CountryCode {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/countryCode/" / v / 1u32);
 }
@@ -630,6 +644,8 @@ pub type CountryCodeV1 = CountryCode;
 #[derive(Debug, Clone, Serialize)]
 pub struct CountryCodeRef<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for CountryCodeRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/countryCode/" / v / 1u32);
 }
@@ -659,6 +675,8 @@ pub type CountryCodeV1Ref<'a> = CountryCodeRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct CountryCodeMut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for CountryCodeMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/countryCode/" / v / 1u32);
 }
@@ -698,6 +716,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct Name(pub Text);
 impl TypeUrl for Name {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/name/" / v / 1u32);
 }
@@ -731,6 +751,8 @@ pub type NameV1 = Name;
 #[derive(Debug, Clone, Serialize)]
 pub struct NameRef<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for NameRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/name/" / v / 1u32);
 }
@@ -758,6 +780,8 @@ pub type NameV1Ref<'a> = NameRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct NameMut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for NameMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/name/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/13-entity-duplicate-identifier.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/13-entity-duplicate-identifier.stdout
@@ -73,6 +73,8 @@ pub struct Country {
 }
 pub type CountryV1 = Country;
 impl TypeUrl for Country {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -171,6 +173,8 @@ pub struct CountryRef<'a> {
 }
 pub type CountryV1Ref<'a> = CountryRef<'a>;
 impl TypeUrl for CountryRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -272,6 +276,8 @@ pub struct CountryMut<'a> {
 }
 pub type CountryV1Mut<'a> = CountryMut<'a>;
 impl TypeUrl for CountryMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -326,6 +332,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct Name(pub Text);
 impl TypeUrl for Name {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/name/" / v / 1u32);
 }
@@ -359,6 +367,8 @@ pub type NameV1 = Name;
 #[derive(Debug, Clone, Serialize)]
 pub struct NameRef<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for NameRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/name/" / v / 1u32);
 }
@@ -386,6 +396,8 @@ pub type NameV1Ref<'a> = NameRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct NameMut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for NameMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/name/" / v / 1u32);
 }
@@ -425,6 +437,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct Name(pub Text);
 impl TypeUrl for Name {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@bob/types/property-type/name/" / v / 1u32);
 }
@@ -458,6 +472,8 @@ pub type NameV1 = Name;
 #[derive(Debug, Clone, Serialize)]
 pub struct NameRef<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for NameRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@bob/types/property-type/name/" / v / 1u32);
 }
@@ -485,6 +501,8 @@ pub type NameV1Ref<'a> = NameRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct NameMut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for NameMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@bob/types/property-type/name/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/14-entity-properties-clash.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/14-entity-properties-clash.stdout
@@ -59,6 +59,8 @@ pub struct Country {
 }
 pub type CountryV1 = Country;
 impl TypeUrl for Country {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -145,6 +147,8 @@ pub struct CountryRef<'a> {
 }
 pub type CountryV1Ref<'a> = CountryRef<'a>;
 impl TypeUrl for CountryRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -228,6 +232,8 @@ pub struct CountryMut<'a> {
 }
 pub type CountryV1Mut<'a> = CountryMut<'a>;
 impl TypeUrl for CountryMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/country/" / v / 1u32);
 }
@@ -282,6 +288,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct Properties(pub Text);
 impl TypeUrl for Properties {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/properties/" / v / 1u32);
 }
@@ -315,6 +323,8 @@ pub type PropertiesV1 = Properties;
 #[derive(Debug, Clone, Serialize)]
 pub struct PropertiesRef<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for PropertiesRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/properties/" / v / 1u32);
 }
@@ -342,6 +352,8 @@ pub type PropertiesV1Ref<'a> = PropertiesRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct PropertiesMut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for PropertiesMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/property-type/properties/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/15-entity-link.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/15-entity-link.stdout
@@ -39,6 +39,8 @@ pub struct PartOf {
 }
 pub type PartOfV1 = PartOf;
 impl TypeUrl for PartOf {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/partOf/" / v / 1u32);
 }
@@ -115,6 +117,8 @@ pub struct PartOfRef<'a> {
 }
 pub type PartOfV1Ref<'a> = PartOfRef<'a>;
 impl TypeUrl for PartOfRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/partOf/" / v / 1u32);
 }
@@ -184,6 +188,8 @@ pub struct PartOfMut<'a> {
 }
 pub type PartOfV1Mut<'a> = PartOfMut<'a>;
 impl TypeUrl for PartOfMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("http://localhost:3000/@alice/types/entity-type/partOf/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/17-property-type-multiple-versions.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/17-property-type-multiple-versions.stdout
@@ -11,6 +11,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct UserId(pub Number);
 impl TypeUrl for UserId {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/user-id/" / v / 2u32);
 }
@@ -44,6 +46,8 @@ pub type UserIdV2 = UserId;
 #[derive(Debug, Clone, Serialize)]
 pub struct UserIdRef<'a>(pub <Number as Type>::Ref<'a>);
 impl TypeUrl for UserIdRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/user-id/" / v / 2u32);
 }
@@ -71,6 +75,8 @@ pub type UserIdV2Ref<'a> = UserIdRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct UserIdMut<'a>(pub <Number as Type>::Mut<'a>);
 impl TypeUrl for UserIdMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/user-id/" / v / 2u32);
 }
@@ -112,6 +118,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct UserIdV1(pub Text);
 impl TypeUrl for UserIdV1 {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/user-id/" / v / 1u32);
 }
@@ -144,6 +152,8 @@ impl PropertyType for UserIdV1 {
 #[derive(Debug, Clone, Serialize)]
 pub struct UserIdV1Ref<'a>(pub <Text as Type>::Ref<'a>);
 impl TypeUrl for UserIdV1Ref<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/user-id/" / v / 1u32);
 }
@@ -170,6 +180,8 @@ impl<'a> PropertyTypeRef<'a> for UserIdV1Ref<'a> {
 #[derive(Debug, Serialize)]
 pub struct UserIdV1Mut<'a>(pub <Text as Type>::Mut<'a>);
 impl TypeUrl for UserIdV1Mut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/user-id/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/18-property-type-data-type-clash.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/18-property-type-data-type-clash.stdout
@@ -11,6 +11,8 @@ use turbine::{
 #[derive(Debug, Clone, Serialize)]
 pub struct Text(pub Text0);
 impl TypeUrl for Text {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/types/property-type/text/" / v / 1u32);
 }
@@ -44,6 +46,8 @@ pub type TextV1 = Text;
 #[derive(Debug, Clone, Serialize)]
 pub struct TextRef<'a>(pub <Text0 as Type>::Ref<'a>);
 impl TypeUrl for TextRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/types/property-type/text/" / v / 1u32);
 }
@@ -71,6 +75,8 @@ pub type TextV1Ref<'a> = TextRef<'a>;
 #[derive(Debug, Serialize)]
 pub struct TextMut<'a>(pub <Text0 as Type>::Mut<'a>);
 impl TypeUrl for TextMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/types/property-type/text/" / v / 1u32);
 }
@@ -120,6 +126,8 @@ pub enum UserId {
     },
 }
 impl TypeUrl for UserId {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/user-id/" / v / 1u32);
 }
@@ -205,6 +213,8 @@ pub enum UserIdRef<'a> {
     },
 }
 impl TypeUrl for UserIdRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/user-id/" / v / 1u32);
 }
@@ -283,6 +293,8 @@ pub enum UserIdMut<'a> {
     },
 }
 impl TypeUrl for UserIdMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/user-id/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/snapshots/19-property-type-inner-type-name.stdout
+++ b/libs/turbine/lib/codegen/tests/snapshots/19-property-type-inner-type-name.stdout
@@ -79,6 +79,8 @@ pub enum UserId {
     Variant1(Vec<_Inner0>),
 }
 impl TypeUrl for UserId {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/user-id/" / v / 1u32);
 }
@@ -156,6 +158,8 @@ pub enum UserIdRef<'a> {
     Variant1(Vec<_Inner1<'a>>),
 }
 impl TypeUrl for UserIdRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/user-id/" / v / 1u32);
 }
@@ -226,6 +230,8 @@ pub enum UserIdMut<'a> {
     Variant1(Vec<_Inner2<'a>>),
 }
 impl TypeUrl for UserIdMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@alice/property-type/user-id/" / v / 1u32);
 }

--- a/libs/turbine/lib/codegen/tests/test_snapshots.rs
+++ b/libs/turbine/lib/codegen/tests/test_snapshots.rs
@@ -52,6 +52,7 @@ fn snapshots() {
         println!("Elapsed: {:?}", now.elapsed().unwrap());
 
         let output = output
+            .files
             .into_iter()
             .map(|(file, stream)| {
                 let mut command = Command::new("rustfmt")

--- a/libs/turbine/lib/skeletor/src/lib.rs
+++ b/libs/turbine/lib/skeletor/src/lib.rs
@@ -17,7 +17,7 @@ use cargo::{
     },
     util::toml_mut::manifest::DepTable,
 };
-use codegen::{AnyTypeRepr, Flavor, ModuleFlavor, Override};
+use codegen::{AnyTypeRepr, Flavor, ModuleFlavor, Output, Override};
 use error_stack::{IntoReport, IntoReportCompat, Result, ResultExt};
 use onlyerror::Error;
 
@@ -237,7 +237,10 @@ fn setup(
 }
 
 pub fn generate(types: Vec<AnyTypeRepr>, config: Config) -> Result<(), Error> {
-    let types = codegen::process(types, codegen::Config {
+    let Output {
+        files: types,
+        utilities,
+    } = codegen::process(types, codegen::Config {
         module: Some(config.style.into()),
         overrides: config.overrides,
         flavors: config.flavors,
@@ -254,7 +257,7 @@ pub fn generate(types: Vec<AnyTypeRepr>, config: Config) -> Result<(), Error> {
         folder.insert(VecDeque::from(directories), file, contents);
     }
 
-    folder.normalize_top_level(config.style);
+    folder.normalize_top_level(config.style, utilities);
 
     folder
         .output(config.root.join("src"))

--- a/libs/turbine/lib/skeletor/src/lib.rs
+++ b/libs/turbine/lib/skeletor/src/lib.rs
@@ -257,7 +257,7 @@ pub fn generate(types: Vec<AnyTypeRepr>, config: Config) -> Result<(), Error> {
         folder.insert(VecDeque::from(directories), file, contents);
     }
 
-    folder.normalize_top_level(config.style, utilities);
+    folder.normalize_top_level(config.style, &utilities);
 
     folder
         .output(config.root.join("src"))

--- a/libs/turbine/lib/skeletor/src/vfs.rs
+++ b/libs/turbine/lib/skeletor/src/vfs.rs
@@ -169,6 +169,7 @@ impl VirtualFolder {
             #![allow(unused_imports)]
 
             use turbine::TypeUrl as _;
+            use turbine::TypeHierarchyResolution as _;
 
             #utilities
 

--- a/libs/turbine/lib/skeletor/src/vfs.rs
+++ b/libs/turbine/lib/skeletor/src/vfs.rs
@@ -168,7 +168,7 @@ impl VirtualFolder {
             #![allow(clippy::missing_safety_doc)] // present in the code generator
             #![allow(unused_imports)]
 
-            use turbine::TypeUrl as _;
+            use turbine::TypeUrl;
             use turbine::TypeHierarchyResolution as _;
 
             #utilities

--- a/libs/turbine/lib/skeletor/src/vfs.rs
+++ b/libs/turbine/lib/skeletor/src/vfs.rs
@@ -157,7 +157,7 @@ impl VirtualFolder {
         result
     }
 
-    pub(crate) fn normalize_top_level(&mut self, style: Style) {
+    pub(crate) fn normalize_top_level(&mut self, style: Style, utilities: &TokenStream) {
         let top_level = quote! {
             #![no_std]
             #![allow(clippy::all)]
@@ -167,6 +167,10 @@ impl VirtualFolder {
             #![allow(clippy::undocumented_unsafe_blocks)] // present in the code generator
             #![allow(clippy::missing_safety_doc)] // present in the code generator
             #![allow(unused_imports)]
+
+            use turbine::TypeUrl as _;
+
+            #utilities
 
             extern crate alloc;
         };

--- a/libs/turbine/lib/turbine/src/hierarchy.rs
+++ b/libs/turbine/lib/turbine/src/hierarchy.rs
@@ -1,0 +1,69 @@
+use core::iter::{empty, once};
+
+use crate::{TypeUrl, VersionedUrlRef};
+
+#[rustfmt::skip]
+macro_rules! all_the_tuples {
+    ($name:ident) => {
+        $name!(T1);
+        $name!(T1, T2);
+        $name!(T1, T2, T3);
+        $name!(T1, T2, T3, T4);
+        $name!(T1, T2, T3, T4, T5);
+        $name!(T1, T2, T3, T4, T5, T6);
+        $name!(T1, T2, T3, T4, T5, T6, T7);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);
+    };
+}
+
+pub trait TypeHierarchyResolution {
+    type Iterator: Iterator<Item = VersionedUrlRef<'static>>;
+
+    fn resolve() -> Self::Iterator;
+}
+
+impl<T> TypeHierarchyResolution for T
+where
+    T: TypeUrl,
+{
+    type Iterator = impl Iterator<Item = VersionedUrlRef<'static>>;
+
+    fn resolve() -> Self::Iterator {
+        once(T::ID)
+    }
+}
+
+impl TypeHierarchyResolution for () {
+    type Iterator = impl Iterator<Item = VersionedUrlRef<'static>>;
+
+    fn resolve() -> Self::Iterator {
+        empty()
+    }
+}
+
+macro_rules! impl_inherits_from {
+    ($($name:ident),*) => {
+        impl<$($name),*> InheritsFrom for ($($name,)*)
+        where
+            $($name: InheritsFrom,)*
+        {
+            type Iterator = impl Iterator<Item = VersionedUrlRef<'static>>;
+
+            fn all() -> Self::Iterator {
+                let iter = empty();
+                $(let iter = iter.chain($name::all());)*
+                iter
+            }
+        }
+    };
+}
+
+all_the_tuples!(impl_inherits_from);

--- a/libs/turbine/lib/turbine/src/hierarchy.rs
+++ b/libs/turbine/lib/turbine/src/hierarchy.rs
@@ -51,15 +51,15 @@ impl TypeHierarchyResolution for () {
 
 macro_rules! impl_inherits_from {
     ($($name:ident),*) => {
-        impl<$($name),*> InheritsFrom for ($($name,)*)
+        impl<$($name),*> TypeHierarchyResolution for ($($name,)*)
         where
-            $($name: InheritsFrom,)*
+            $($name: TypeHierarchyResolution,)*
         {
             type Iterator = impl Iterator<Item = VersionedUrlRef<'static>>;
 
-            fn all() -> Self::Iterator {
+            fn resolve() -> Self::Iterator {
                 let iter = empty();
-                $(let iter = iter.chain($name::all());)*
+                $(let iter = iter.chain($name::resolve());)*
                 iter
             }
         }

--- a/libs/turbine/lib/turbine/src/lib.rs
+++ b/libs/turbine/lib/turbine/src/lib.rs
@@ -2,8 +2,7 @@
 #![feature(error_in_core)]
 #![feature(never_type)]
 #![feature(type_alias_impl_trait)]
-#![allow(incomplete_features)] // generic_const_exprs are needed for array
-#![feature(generic_const_exprs)]
+#![feature(impl_trait_in_assoc_type)]
 
 extern crate alloc;
 

--- a/libs/turbine/lib/turbine/src/lib.rs
+++ b/libs/turbine/lib/turbine/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![feature(error_in_core)]
 #![feature(never_type)]
+#![feature(type_alias_impl_trait)]
 
 extern crate alloc;
 
@@ -15,12 +16,15 @@ use crate::entity::{Entity, LinkData};
 
 pub mod entity;
 mod error;
+mod hierarchy;
 mod polyfill;
 mod serialize;
 pub mod types;
 
 pub use error::{GenericEntityError, GenericPropertyError};
 pub use polyfill::{fold_iter_reports, fold_tuple_reports};
+
+pub use crate::hierarchy::TypeHierarchyResolution;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct BaseUrlRef<'a>(&'a str);
@@ -130,6 +134,8 @@ macro_rules! url {
 }
 
 pub trait TypeUrl {
+    type InheritsFrom: TypeHierarchyResolution;
+
     const ID: VersionedUrlRef<'static>;
 }
 

--- a/libs/turbine/lib/turbine/src/lib.rs
+++ b/libs/turbine/lib/turbine/src/lib.rs
@@ -2,6 +2,8 @@
 #![feature(error_in_core)]
 #![feature(never_type)]
 #![feature(type_alias_impl_trait)]
+#![allow(incomplete_features)] // generic_const_exprs are needed for array
+#![feature(generic_const_exprs)]
 
 extern crate alloc;
 

--- a/libs/turbine/lib/turbine/src/lib.rs
+++ b/libs/turbine/lib/turbine/src/lib.rs
@@ -27,7 +27,7 @@ pub use polyfill::{fold_iter_reports, fold_tuple_reports};
 
 pub use crate::hierarchy::TypeHierarchyResolution;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct BaseUrlRef<'a>(&'a str);
 
 impl<'a> BaseUrlRef<'a> {
@@ -56,7 +56,7 @@ impl<'a> BaseUrlRef<'a> {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct VersionedUrlRef<'a> {
     base: BaseUrlRef<'a>,
     version: u32,

--- a/libs/turbine/lib/turbine/src/types/data/boolean.rs
+++ b/libs/turbine/lib/turbine/src/types/data/boolean.rs
@@ -40,6 +40,8 @@ impl DerefMut for Boolean {
 }
 
 impl TypeUrl for Boolean {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/data-type/boolean/" / v / 1);
 }
@@ -106,6 +108,8 @@ impl DerefMut for BooleanMut<'_> {
 }
 
 impl TypeUrl for BooleanMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/data-type/boolean/" / v / 1);
 }

--- a/libs/turbine/lib/turbine/src/types/data/empty_list.rs
+++ b/libs/turbine/lib/turbine/src/types/data/empty_list.rs
@@ -29,6 +29,8 @@ impl Serialize for EmptyList {
 }
 
 impl TypeUrl for EmptyList {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/data-type/emptyList/" / v / 1);
 }

--- a/libs/turbine/lib/turbine/src/types/data/null.rs
+++ b/libs/turbine/lib/turbine/src/types/data/null.rs
@@ -17,6 +17,8 @@ pub enum NullError {
 pub struct Null;
 
 impl TypeUrl for Null {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/data-type/null/" / v / 1);
 }

--- a/libs/turbine/lib/turbine/src/types/data/number.rs
+++ b/libs/turbine/lib/turbine/src/types/data/number.rs
@@ -43,6 +43,8 @@ impl Deref for Number {
 }
 
 impl TypeUrl for Number {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/data-type/number/" / v / 1);
 }
@@ -84,6 +86,8 @@ impl Deref for NumberRef<'_> {
 }
 
 impl TypeUrl for NumberRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/data-type/number/" / v / 1);
 }
@@ -126,6 +130,8 @@ impl DerefMut for NumberMut<'_> {
 }
 
 impl TypeUrl for NumberMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/data-type/number/" / v / 1);
 }

--- a/libs/turbine/lib/turbine/src/types/data/object.rs
+++ b/libs/turbine/lib/turbine/src/types/data/object.rs
@@ -50,6 +50,8 @@ impl DerefMut for Object {
 }
 
 impl TypeUrl for Object {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/data-type/object/" / v / 1);
 }
@@ -91,6 +93,8 @@ impl Deref for ObjectRef<'_> {
 }
 
 impl TypeUrl for ObjectRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/data-type/object/" / v / 1);
 }
@@ -131,6 +135,8 @@ impl DerefMut for ObjectMut<'_> {
 }
 
 impl TypeUrl for ObjectMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/data-type/object/" / v / 1);
 }

--- a/libs/turbine/lib/turbine/src/types/data/text.rs
+++ b/libs/turbine/lib/turbine/src/types/data/text.rs
@@ -50,6 +50,8 @@ impl DerefMut for Text {
 }
 
 impl TypeUrl for Text {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/data-type/object/" / v / 1);
 }
@@ -98,6 +100,8 @@ impl Deref for TextRef<'_> {
 }
 
 impl TypeUrl for TextRef<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/data-type/object/" / v / 1);
 }
@@ -139,6 +143,8 @@ impl DerefMut for TextMut<'_> {
 }
 
 impl TypeUrl for TextMut<'_> {
+    type InheritsFrom = ();
+
     const ID: VersionedUrlRef<'static> =
         url!("https://blockprotocol.org/@blockprotocol/types/data-type/object/" / v / 1);
 }

--- a/libs/turbine/rust-toolchain.toml
+++ b/libs/turbine/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-02-20"
+channel = "nightly-2023-05-22"
 components = ["cargo", "clippy", "rustfmt", "rust-std", "rust-src"]


### PR DESCRIPTION
This enables support for `allOf` for entities and unifies the types accordingly. This also adds a new associated type: `InheritsFrom`, which can be queried to get the URLs of all types it inherits from.

`InheritsFrom` is structured so that it is possible to add more functionality in the future (it's just a tuple of `TypeUrl` types).
