### PR TITLE
`turbine`: miscellaneous fixes 

### DIFF
--- a/libs/turbine/bin/cli/Cargo.toml
+++ b/libs/turbine/bin/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cli"
+name = "turbine-cli"
 version = "0.1.0"
 edition = "2021"
 

--- a/libs/turbine/lib/skeletor/src/vfs.rs
+++ b/libs/turbine/lib/skeletor/src/vfs.rs
@@ -167,6 +167,7 @@ impl VirtualFolder {
             #![allow(clippy::undocumented_unsafe_blocks)] // present in the code generator
             #![allow(clippy::missing_safety_doc)] // present in the code generator
             #![allow(unused_imports)]
+            #![allow(unused_variables)]
 
             use turbine::TypeUrl;
             use turbine::TypeHierarchyResolution as _;


### PR DESCRIPTION
This introduces some minor miscellaneous fixes to `turbine`, mainly it allows unused variables in generated code (there is no good way to _not_ generate them, except with a lot more logic - and edge cases), and renamed `cli` to `turbine-cli`. This allows installation via `cargo install`!