### PR TITLE
`turbine`: use `__` as environment separator

### DIFF
--- a/libs/turbine/bin/cli/src/cmd_lib.rs
+++ b/libs/turbine/bin/cli/src/cmd_lib.rs
@@ -262,7 +262,7 @@ pub(crate) fn load_config(lib: Lib) -> core::result::Result<Config, figment::Err
     let mut figment = Figment::new()
         .merge(Toml::file("turbine.toml"))
         .merge(Toml::file(".turbine.toml"))
-        .merge(Env::prefixed("TURBINE_"));
+        .merge(Env::prefixed("TURBINE_").split("__").global());
 
     if let Some(root) = root {
         figment = figment.merge(("root".to_owned(), figment::value::Value::serialize(root)?));


### PR DESCRIPTION
By default `figment` uses `.` as separator for env variables, this is not very convenient in CI where using `.` in env variables is not really possible. This changes it to `__`, which is more common for nested env variables.