### PR TITLE
`turbine`: support profiles

### DIFF
--- a/libs/turbine/bin/cli/Cargo.toml
+++ b/libs/turbine/bin/cli/Cargo.toml
@@ -12,6 +12,8 @@ reqwest = { version = "0.11.17", features = ['json', "blocking"] }
 serde_json = "1.0.96"
 thiserror = "1.0.40"
 error-stack = "0.3.1"
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.17", features = ['env-filter'] }
 serde = { version = "1.0.160", features = ['derive'] }
 toml = { version = "0.7.3" }
 figment = { version = "0.10.8", features = ['env', 'toml'] }

--- a/libs/turbine/bin/cli/src/cmd_lib.rs
+++ b/libs/turbine/bin/cli/src/cmd_lib.rs
@@ -272,7 +272,7 @@ pub(crate) fn load_config(lib: Lib) -> core::result::Result<Config, figment::Err
     for name in &["turbine", ".turbine"] {
         figment = figment.merge(Toml::file(format!("{name}.toml")));
 
-        for (abbreviation, name) in &[
+        for (abbreviation, full) in &[
             ("prod", "production"),
             ("production", "production"),
             ("dev", "development"),
@@ -281,7 +281,7 @@ pub(crate) fn load_config(lib: Lib) -> core::result::Result<Config, figment::Err
             ("test", "test"),
         ] {
             let path = format!("{name}.{abbreviation}.toml");
-            figment = figment.merge(Toml::file(path).profile(Profile::const_new(name)));
+            figment = figment.merge(Toml::file(path).profile(Profile::const_new(full)));
         }
     }
 

--- a/libs/turbine/bin/cli/src/cmd_lib.rs
+++ b/libs/turbine/bin/cli/src/cmd_lib.rs
@@ -264,9 +264,16 @@ pub(crate) fn load_config(lib: Lib) -> core::result::Result<Config, figment::Err
     for name in &["turbine", ".turbine"] {
         figment = figment.merge(Toml::file(format!("{name}.toml")));
 
-        for profile in &["prod", "dev", "test"] {
-            let path = format!("{name}.{profile}.toml");
-            figment = figment.merge(Toml::file(path).profile(Profile::const_new(profile)));
+        for (abbreviation, name) in &[
+            ("prod", "production"),
+            ("production", "production"),
+            ("dev", "development"),
+            ("devel", "development"),
+            ("development", "development"),
+            ("test", "test"),
+        ] {
+            let path = format!("{name}.{abbreviation}.toml");
+            figment = figment.merge(Toml::file(path).profile(Profile::const_new(name)));
         }
     }
 

--- a/libs/turbine/bin/cli/src/cmd_lib.rs
+++ b/libs/turbine/bin/cli/src/cmd_lib.rs
@@ -262,7 +262,12 @@ pub(crate) fn load_config(lib: Lib) -> core::result::Result<Config, figment::Err
     let mut figment = Figment::new()
         .merge(Toml::file("turbine.toml"))
         .merge(Toml::file("turbine.prod.toml").profile(Profile::const_new("production")))
+        .merge(Toml::file("turbine.dev.toml").profile(Profile::const_new("development")))
+        .merge(Toml::file("turbine.test.toml").profile(Profile::const_new("test")))
         .merge(Toml::file(".turbine.toml"))
+        .merge(Toml::file(".turbine.prod.toml").profile(Profile::const_new("production")))
+        .merge(Toml::file(".turbine.dev.toml").profile(Profile::const_new("development")))
+        .merge(Toml::file(".turbine.test.toml").profile(Profile::const_new("test")))
         .merge(Env::prefixed("TURBINE_").split("__").global());
 
     if let Some(root) = root {

--- a/libs/turbine/lib/skeletor/src/lib.rs
+++ b/libs/turbine/lib/skeletor/src/lib.rs
@@ -57,7 +57,9 @@ pub struct Config {
 
     pub overrides: Vec<Override>,
     pub flavors: Vec<Flavor>,
+
     pub force: bool,
+    pub timings: bool,
 
     pub turbine: Dependency,
 }
@@ -236,6 +238,9 @@ fn setup(
     Ok((abs_root, cargo_config))
 }
 
+/// # Errors
+///
+/// Will return an error if the codegen fails or if the setup fails.
 pub fn generate(types: Vec<AnyTypeRepr>, config: Config) -> Result<(), Error> {
     let Output {
         files: types,
@@ -244,6 +249,7 @@ pub fn generate(types: Vec<AnyTypeRepr>, config: Config) -> Result<(), Error> {
         module: Some(config.style.into()),
         overrides: config.overrides,
         flavors: config.flavors,
+        timings: config.timings,
     })
     .change_context(Error::Codegen)?;
 
@@ -263,24 +269,6 @@ pub fn generate(types: Vec<AnyTypeRepr>, config: Config) -> Result<(), Error> {
         .output(config.root.join("src"))
         .into_report()
         .change_context(Error::Io)?;
-
-    // let workspace = Workspace::new(&abs_root.join("Cargo.toml"), &cargo_config)
-    //     .into_report()
-    //     .change_context(Error::Codegen)?;
-
-    // cargo::ops::fix(&workspace, &mut FixOptions {
-    //     edition: true,
-    //     idioms: true,
-    //     compile_opts: CompileOptions::new(&cargo_config, CompileMode::Check { test: true })
-    //         .into_report()
-    //         .change_context(Error::Codegen)?,
-    //     allow_dirty: true,
-    //     allow_no_vcs: true,
-    //     allow_staged: true,
-    //     broken_code: false,
-    // })
-    // .into_report()
-    // .change_context(Error::Codegen)?;
 
     let mut child = Command::new("cargo-fmt")
         .arg("--all")

--- a/libs/turbine/lib/skeletor/src/vfs.rs
+++ b/libs/turbine/lib/skeletor/src/vfs.rs
@@ -168,6 +168,7 @@ impl VirtualFolder {
             #![allow(clippy::missing_safety_doc)] // present in the code generator
             #![allow(unused_imports)]
             #![allow(unused_variables)]
+            #![allow(unused_mut)]
 
             use turbine::TypeUrl;
             use turbine::TypeHierarchyResolution as _;


### PR DESCRIPTION
This adds support for profiles, which can be enabled via the `TURBINE_PROFILE` env variable. These profiles are partial overrides and can be in the `turbine.prod.toml`, `turbine.dev.toml` and `turbine.test.toml` files.

As a drive-by, it also adds the `--timings` CLI flag, which determines the timings of the different operations in the turbine-cli.