### PR TITLE
`turbine`: derive `PartialEq` + `Eq` for types

### DIFF
--- a/libs/turbine/lib/codegen/src/entity.rs
+++ b/libs/turbine/lib/codegen/src/entity.rs
@@ -215,8 +215,14 @@ fn generate_type(
     let mut property_derives = vec![format_ident!("Debug")];
 
     if variant == Variant::Owned || variant == Variant::Ref {
-        derives.push(format_ident!("Clone"));
-        property_derives.push(format_ident!("Clone"));
+        for derive in [
+            format_ident!("Clone"),
+            format_ident!("PartialEq"),
+            format_ident!("Eq"),
+        ] {
+            derives.push(derive.clone());
+            property_derives.push(derive);
+        }
     }
 
     if !properties.is_empty() {

--- a/libs/turbine/lib/codegen/src/property/type_.rs
+++ b/libs/turbine/lib/codegen/src/property/type_.rs
@@ -156,7 +156,9 @@ impl<'a> TypeGenerator<'a> {
 
     pub(super) fn finish(mut self) -> Type {
         let derive = match self.variant {
-            Variant::Owned | Variant::Ref => quote!(#[derive(Debug, Clone, Serialize)]),
+            Variant::Owned | Variant::Ref => {
+                quote!(#[derive(Debug, PartialEq, Eq, Clone, Serialize)])
+            }
             Variant::Mut => quote!(#[derive(Debug, Serialize)]),
         };
 

--- a/libs/turbine/lib/turbine/src/types/data/boolean.rs
+++ b/libs/turbine/lib/turbine/src/types/data/boolean.rs
@@ -26,6 +26,15 @@ impl Boolean {
     }
 }
 
+impl<T> From<T> for Boolean
+where
+    T: Into<bool>,
+{
+    fn from(value: T) -> Self {
+        Self(value.into())
+    }
+}
+
 impl Deref for Boolean {
     type Target = bool;
 

--- a/libs/turbine/lib/turbine/src/types/data/boolean.rs
+++ b/libs/turbine/lib/turbine/src/types/data/boolean.rs
@@ -16,7 +16,7 @@ pub enum BooleanError {
     NotABoolean(Value),
 }
 
-#[derive(Debug, Copy, Clone, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct Boolean(bool);
 
 impl Boolean {

--- a/libs/turbine/lib/turbine/src/types/data/empty_list.rs
+++ b/libs/turbine/lib/turbine/src/types/data/empty_list.rs
@@ -17,7 +17,7 @@ pub enum EmptyListError {
     NotEmpty,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EmptyList;
 
 impl Serialize for EmptyList {

--- a/libs/turbine/lib/turbine/src/types/data/null.rs
+++ b/libs/turbine/lib/turbine/src/types/data/null.rs
@@ -14,7 +14,7 @@ pub enum NullError {
     NotNull(Value),
 }
 
-#[derive(Debug, Copy, Clone, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct Null;
 
 impl TypeUrl for Null {

--- a/libs/turbine/lib/turbine/src/types/data/number.rs
+++ b/libs/turbine/lib/turbine/src/types/data/number.rs
@@ -16,7 +16,7 @@ pub enum NumberError {
     NotANumber(Value),
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct Number(serde_json::Number);
 
 impl Number {
@@ -79,7 +79,7 @@ impl DataType for Number {
     }
 }
 
-#[derive(Debug, Copy, Clone, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct NumberRef<'a>(&'a serde_json::Number);
 
 impl Deref for NumberRef<'_> {

--- a/libs/turbine/lib/turbine/src/types/data/object.rs
+++ b/libs/turbine/lib/turbine/src/types/data/object.rs
@@ -17,7 +17,7 @@ pub enum ObjectError {
     NotAnObject(Value),
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Object(serde_json::Map<String, Value>);
 
 impl Object {
@@ -86,7 +86,7 @@ impl DataType for Object {
     }
 }
 
-#[derive(Debug, Copy, Clone, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize)]
 pub struct ObjectRef<'a>(&'a serde_json::Map<String, Value>);
 
 impl Deref for ObjectRef<'_> {

--- a/libs/turbine/lib/turbine/src/types/data/text.rs
+++ b/libs/turbine/lib/turbine/src/types/data/text.rs
@@ -17,7 +17,7 @@ pub enum TextError {
     NotText(Value),
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct Text(String);
 
 impl Text {
@@ -86,7 +86,7 @@ impl DataType for Text {
     }
 }
 
-#[derive(Debug, Copy, Clone, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct TextRef<'a>(&'a str);
 
 impl<'a> TextRef<'a> {


### PR DESCRIPTION
This PR enables `PartialEq` and `Eq` derives on entities and references (but not mutable ones)