### PR TITLE
`turbine`: Fix HASH parity

### DIFF
--- a/libs/turbine/lib/turbine/src/entity.rs
+++ b/libs/turbine/lib/turbine/src/entity.rs
@@ -64,6 +64,7 @@ impl Serialize for EntityId {
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ProvenanceMetadata {
     pub record_created_by_id: Uuid,
+    pub record_archived_by_id: Option<Uuid>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
https://github.com/hashintel/hash/pull/2856 added a new field to the `ProvenanceMetadata` (`record_archived_by_id`).

Ideally, we would generate this from the sources, but we're not there yet, and these fields are not expected to change much.