### PR TITLE
Skip serializing a field if not required

### DIFF
--- a/libs/turbine/lib/codegen/src/shared.rs
+++ b/libs/turbine/lib/codegen/src/shared.rs
@@ -411,12 +411,16 @@ pub(crate) fn generate_property(
         }
     };
 
+    let mut skip = None;
+
     if !required {
+        skip = Some(quote!(#[serde(skip_serializing_if = "Option::is_none")]));
         type_ = quote!(Option<#type_>);
     }
 
     quote! {
         #[serde(rename = #url)]
+        #skip
         #visibility #name: #type_
     }
 }


### PR DESCRIPTION
Currently `Option<T>` is serialized as `null` if a field is not required, this is incorrect, as the field needs to be absent not null, otherwise entity validation fails.