### PR TITLE
`turbine`: fix nested property type generation & fast validation

### DIFF
--- a/libs/turbine/lib/codegen/src/entity.rs
+++ b/libs/turbine/lib/codegen/src/entity.rs
@@ -133,7 +133,7 @@ fn generate_properties_is_valid_properties(
 
     if properties.is_empty() {
         quote! {
-            fn is_valid_value(value: &serde_json::value::Value) -> bool {
+            fn is_valid_value(_: &HashMap<String, serde_json::value::Value>) -> bool {
                 true
             }
         }
@@ -141,7 +141,7 @@ fn generate_properties_is_valid_properties(
         let body = generate_properties_is_valid_value(properties);
 
         quote! {
-            fn is_valid_value(value: &serde_json::value::Value) -> bool {
+            fn is_valid_value(properties: &HashMap<String, serde_json::value::Value>) -> bool {
                 #body
             }
         }
@@ -471,12 +471,6 @@ fn generate_owned(
                     #(#link_data: &self.link_data)*
                 }
             }
-
-            fn is_valid_entity(value: &Entity) -> bool {
-                value.metadata.entity_type_id == Self::ID &&
-                    #(value.#link_data.is_some() &&)*
-                    Properties::is_valid_value(&value.properties.0)
-            }
         }
 
         impl EntityType for #name {
@@ -503,6 +497,12 @@ fn generate_owned(
                         )
                     )
                 }
+            }
+
+            fn is_valid_entity(value: &Entity) -> bool {
+                value.metadata.entity_type_id == Self::ID &&
+                    #(value.#link_data.is_some() &&)*
+                    Properties::is_valid_value(&value.properties.0)
             }
         }
 

--- a/libs/turbine/lib/codegen/src/entity.rs
+++ b/libs/turbine/lib/codegen/src/entity.rs
@@ -500,7 +500,7 @@ fn generate_owned(
             }
 
             fn is_valid_entity(value: &Entity) -> bool {
-                value.metadata.entity_type_id == Self::ID &&
+                Self::ID == value.metadata.entity_type_id &&
                     #(value.#link_data.is_some() &&)*
                     Properties::is_valid_value(&value.properties.0)
             }

--- a/libs/turbine/lib/codegen/src/property.rs
+++ b/libs/turbine/lib/codegen/src/property.rs
@@ -223,6 +223,7 @@ impl<'a> PropertyTypeGenerator<'a> {
             def,
             impl_try_from_value,
             impl_conversion,
+            impl_is_valid_value,
             ..
         } = self.type_(&name, Variant::Owned);
 
@@ -250,6 +251,8 @@ impl<'a> PropertyTypeGenerator<'a> {
                 fn try_from_value(value: serde_json::Value) -> Result<Self, Self::Error> {
                     #impl_try_from_value
                 }
+
+                #impl_is_valid_value
             }
 
             #alias

--- a/libs/turbine/lib/codegen/src/property/inner.rs
+++ b/libs/turbine/lib/codegen/src/property/inner.rs
@@ -116,13 +116,18 @@ pub(super) struct InnerGenerator<'a> {
 }
 
 impl<'a> InnerGenerator<'a> {
-    pub(super) fn finish(self) -> Ident {
+    pub(super) fn finish(self) -> (Ident, SelfVariants) {
         let names = self.state.inner.get_or_insert(&self.state.stack);
 
         let (name, index) = names.to_variant(self.variant);
         let NameVariants {
             owned, ref_, mut_, ..
         } = names;
+        let self_variants = SelfVariants {
+            owned: owned.to_token_stream(),
+            ref_: ref_.to_token_stream(),
+            mut_: mut_.to_token_stream(),
+        };
 
         self.state.stack.push(PathSegment::Inner { index });
         let Type {
@@ -136,11 +141,7 @@ impl<'a> InnerGenerator<'a> {
             id: self.id,
             name: &name,
             variant: self.variant,
-            self_variants: SelfVariants {
-                owned: owned.to_token_stream(),
-                ref_: ref_.to_token_stream(),
-                mut_: mut_.to_token_stream(),
-            },
+            self_variants: self_variants.clone(),
             values: self.values,
             resolver: self.resolver,
             locations: self.locations,
@@ -174,6 +175,6 @@ impl<'a> InnerGenerator<'a> {
             }
         ));
 
-        name
+        (name, self_variants)
     }
 }

--- a/libs/turbine/lib/codegen/src/property/inner.rs
+++ b/libs/turbine/lib/codegen/src/property/inner.rs
@@ -130,6 +130,7 @@ impl<'a> InnerGenerator<'a> {
             lifetime,
             impl_ty,
             impl_try_from_value,
+            impl_is_valid_value,
             impl_conversion,
         } = TypeGenerator {
             id: self.id,
@@ -154,6 +155,11 @@ impl<'a> InnerGenerator<'a> {
             Variant::Mut => Some(quote!(&'a mut)),
         };
 
+        let is_valid_value = match self.variant {
+            Variant::Owned => impl_is_valid_value,
+            _ => quote!(),
+        };
+
         self.state.extra.push(quote!(
             #def
 
@@ -161,6 +167,8 @@ impl<'a> InnerGenerator<'a> {
                 fn try_from_value(value: #value_ref serde_json::Value) -> Result<Self, GenericPropertyError> {
                     #impl_try_from_value
                 }
+
+                #is_valid_value
 
                 #impl_conversion
             }

--- a/libs/turbine/lib/codegen/src/property/inner.rs
+++ b/libs/turbine/lib/codegen/src/property/inner.rs
@@ -127,6 +127,7 @@ impl<'a> InnerGenerator<'a> {
         self.state.stack.push(PathSegment::Inner { index });
         let Type {
             def,
+            lifetime,
             impl_ty,
             impl_try_from_value,
             impl_conversion,
@@ -156,8 +157,8 @@ impl<'a> InnerGenerator<'a> {
         self.state.extra.push(quote!(
             #def
 
-            impl #impl_ty {
-                fn try_from_value(value: #value_ref serde_json::Value) -> Result<Self, GenericPropertError> {
+            impl #lifetime #impl_ty {
+                fn try_from_value(value: #value_ref serde_json::Value) -> Result<Self, GenericPropertyError> {
                     #impl_try_from_value
                 }
 

--- a/libs/turbine/lib/codegen/src/property/property_value.rs
+++ b/libs/turbine/lib/codegen/src/property/property_value.rs
@@ -226,7 +226,7 @@ impl<'a> PropertyValueGenerator<'a> {
         let is_valid_value = match self.variant {
             Variant::Owned => {
                 quote! {
-                    fn is_valid_value(value: &serde_json::Value) -> bool {
+                    {
                         <#owned_type_name as DataType>::is_valid_value(value)
                     }
                 }
@@ -387,7 +387,7 @@ impl<'a> PropertyValueGenerator<'a> {
                 let body = shared::generate_properties_is_valid_value(&properties);
 
                 quote! {
-                    fn is_valid_value(value: &serde_json::Value) -> bool {
+                    {
                         let serde_json::Value::Object(ref properties) = value else {
                             break 'variant false
                         };
@@ -590,7 +590,7 @@ impl<'a> PropertyValueGenerator<'a> {
         let is_valid_value = match self.variant {
             Variant::Owned => {
                 quote! {
-                    fn is_valid_value(value: &serde_json::Value) -> bool {
+                    {
                         let serde_json::Value::Array(array) = value else {
                             break 'variant false
                         };

--- a/libs/turbine/lib/codegen/src/property/type_.rs
+++ b/libs/turbine/lib/codegen/src/property/type_.rs
@@ -18,6 +18,7 @@ use crate::{
 
 pub(super) struct Type {
     pub(super) def: TokenStream,
+    pub(super) lifetime: Option<TokenStream>,
     // TODO: rename
     pub(super) impl_ty: TokenStream,
     pub(super) impl_try_from_value: TokenStream,
@@ -42,7 +43,7 @@ impl<'a> TypeGenerator<'a> {
         &mut self,
         value: &PropertyValues,
         derive: &TokenStream,
-        lifetime: Option<&TokenStream>,
+        lifetime: Option<TokenStream>,
     ) -> Type {
         let name = self.name;
 
@@ -106,6 +107,7 @@ impl<'a> TypeGenerator<'a> {
 
         Type {
             def,
+            lifetime,
             impl_ty: quote!(#name #lifetime),
             impl_try_from_value: try_from,
             impl_conversion,
@@ -168,7 +170,7 @@ impl<'a> TypeGenerator<'a> {
         };
 
         if let [value] = self.values {
-            return self.hoist(value, &derive, lifetime.as_ref());
+            return self.hoist(value, &derive, lifetime);
         }
 
         // we cannot hoist and therefore need to create an enum
@@ -242,6 +244,7 @@ impl<'a> TypeGenerator<'a> {
 
         Type {
             def,
+            lifetime,
             impl_ty: quote!(#name #lifetime),
             impl_try_from_value: try_from,
             impl_conversion: self.impl_conversion(&conversion),

--- a/libs/turbine/lib/codegen/src/property/type_.rs
+++ b/libs/turbine/lib/codegen/src/property/type_.rs
@@ -243,7 +243,7 @@ impl<'a> TypeGenerator<'a> {
                     quote! {
                         // LLVM is smart enough to optimize away the immediate function invocation
                         // we use this to be able to use `return` in the generated code.
-                        let is_valid = (|value| #is_valid_value)(#deref value);
+                        let is_valid = (|value: &serde_json::value::Value| #is_valid_value)(#deref value);
 
                         if is_valid {
                             return #try_from;

--- a/libs/turbine/lib/codegen/src/property/type_.rs
+++ b/libs/turbine/lib/codegen/src/property/type_.rs
@@ -19,9 +19,10 @@ use crate::{
 pub(super) struct Type {
     pub(super) def: TokenStream,
     pub(super) lifetime: Option<TokenStream>,
-    // TODO: rename
+
     pub(super) impl_ty: TokenStream,
     pub(super) impl_try_from_value: TokenStream,
+    pub(super) impl_is_valid_value: TokenStream,
     pub(super) impl_conversion: TokenStream,
 }
 

--- a/libs/turbine/lib/codegen/src/property/type_.rs
+++ b/libs/turbine/lib/codegen/src/property/type_.rs
@@ -105,10 +105,12 @@ impl<'a> TypeGenerator<'a> {
             }
         };
 
+        let impl_ty = quote!(#name #lifetime);
+
         Type {
             def,
             lifetime,
-            impl_ty: quote!(#name #lifetime),
+            impl_ty,
             impl_try_from_value: try_from,
             impl_conversion,
         }
@@ -242,10 +244,12 @@ impl<'a> TypeGenerator<'a> {
             }
         };
 
+        let impl_ty = quote!(#name #lifetime);
+
         Type {
             def,
             lifetime,
-            impl_ty: quote!(#name #lifetime),
+            impl_ty,
             impl_try_from_value: try_from,
             impl_conversion: self.impl_conversion(&conversion),
         }

--- a/libs/turbine/lib/codegen/src/shared.rs
+++ b/libs/turbine/lib/codegen/src/shared.rs
@@ -258,6 +258,7 @@ pub(crate) fn generate_properties_is_valid_value(
             },
         )| {
             let index = base.as_str();
+            let mut label = None;
 
             let access = quote!(let value = properties.get(#index););
 
@@ -268,6 +269,7 @@ pub(crate) fn generate_properties_is_valid_value(
             } else {
                 // the value is wrapped in `Option<>` and can be missing!
                 // therefore we break out of the block and continue with the next property
+                label = Some(quote!('property:));
                 quote! {
                     let Some(value) = value else { break 'property; };
                 }
@@ -295,7 +297,7 @@ pub(crate) fn generate_properties_is_valid_value(
             };
 
             quote! {
-                'property: {
+                #label {
                     #access
 
                     #unwrap

--- a/libs/turbine/lib/codegen/src/shared.rs
+++ b/libs/turbine/lib/codegen/src/shared.rs
@@ -377,13 +377,10 @@ pub(crate) fn generate_properties_try_from_value(
                 }
             } else {
                 // the value is wrapped in `Option<>` and can be missing!
+                // null != missing, therefore can only break out if missing, not if null.
                 quote! {
                     let Some(value) = value else {
                         break 'property Ok(None);
-                    };
-
-                    if value.is_null() {
-                        break 'property Ok(None)
                     };
                 }
             };

--- a/libs/turbine/lib/codegen/src/shared.rs
+++ b/libs/turbine/lib/codegen/src/shared.rs
@@ -211,11 +211,14 @@ fn generate_fold(properties: &BTreeMap<&BaseUrl, Property>) -> TokenStream {
     }
 
     if let Some(remainder) = chunks.into_remainder() {
-        let result = format_ident!("__report{index}");
         let chunk: Vec<_> = remainder.collect();
 
-        fold.push(quote!(let #result = turbine::fold_tuple_reports((#(#chunk,)*))));
-        unfold.push((quote!((#(#chunk,)*)), result));
+        if !chunk.is_empty() {
+            let result = format_ident!("__report{index}");
+
+            fold.push(quote!(let #result = turbine::fold_tuple_reports((#(#chunk,)*))));
+            unfold.push((quote!((#(#chunk,)*)), result));
+        }
     }
 
     // this creates an implicit limit of 16*16 elements (~> 256 element)

--- a/libs/turbine/lib/codegen/src/shared.rs
+++ b/libs/turbine/lib/codegen/src/shared.rs
@@ -259,17 +259,17 @@ pub(crate) fn generate_properties_is_valid_value(
         )| {
             let index = base.as_str();
 
-            let access = quote!(let value = properties.get(#index));
+            let access = quote!(let value = properties.get(#index););
 
             let unwrap = if *required {
                 quote! {
-                    let Some(value) = value else { return false; }
+                    let Some(value) = value else { return false; };
                 }
             } else {
                 // the value is wrapped in `Option<>` and can be missing!
                 // therefore we break out of the block and continue with the next property
                 quote! {
-                    let Some(value) = value else { break 'property; }
+                    let Some(value) = value else { break 'property; };
                 }
             };
 

--- a/libs/turbine/lib/codegen/src/shared.rs
+++ b/libs/turbine/lib/codegen/src/shared.rs
@@ -251,7 +251,7 @@ pub(crate) fn generate_properties_is_valid_value(
         |(
             base,
             Property {
-                name,
+                name: _,
                 type_,
                 kind,
                 required,

--- a/libs/turbine/lib/turbine/Cargo.toml
+++ b/libs/turbine/lib/turbine/Cargo.toml
@@ -12,8 +12,6 @@ error-stack = { workspace = true, default-features = false }
 time = { version = "0.3.20", features = ['serde-well-known'], default-features = false }
 hashbrown = { version = "0.14.0", default-features = false, features = ["ahash", "serde"] }
 uuid = { version = "1.3.1", features = ['serde'], default-features = false }
-
-# Once stabilized move to 0.1.3, but we need the fully quantified paths
-onlyerror = { git = "https://github.com/parasyte/onlyerror", default-features = false }
+onlyerror = "0.1.3"
 
 type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "542836" }

--- a/libs/turbine/lib/turbine/Cargo.toml
+++ b/libs/turbine/lib/turbine/Cargo.toml
@@ -12,6 +12,6 @@ error-stack = { workspace = true, default-features = false }
 time = { version = "0.3.20", features = ['serde-well-known'], default-features = false }
 hashbrown = { version = "0.14.0", default-features = false, features = ["ahash", "serde"] }
 uuid = { version = "1.3.1", features = ['serde'], default-features = false }
-onlyerror = "0.1.3"
+onlyerror = { version = "0.1.3", default-features = false }
 
 type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "542836" }

--- a/libs/turbine/lib/turbine/src/error.rs
+++ b/libs/turbine/lib/turbine/src/error.rs
@@ -14,6 +14,8 @@ pub enum GenericPropertyError {
     Property(&'static str),
     #[error("expected object as value")]
     ExpectedObject,
+    #[error("invalid value")]
+    InvalidValue,
 }
 
 #[derive(Debug, Copy, Clone, Error)]

--- a/libs/turbine/lib/turbine/src/lib.rs
+++ b/libs/turbine/lib/turbine/src/lib.rs
@@ -202,6 +202,9 @@ where
     ///
     /// if the value is malformed and not of the correct shape
     fn try_from_value(value: serde_json::Value) -> Result<Self, Self::Error>;
+
+    /// Equivalent to [`Self::try_from_value`] but fails-fast if the valid is not of expected shape.
+    fn is_valid_value(value: &serde_json::Value) -> bool;
 }
 
 pub trait PropertyTypeRef<'a>: Serialize + TypeRef {
@@ -233,6 +236,9 @@ where
     ///
     /// if the value is malformed and not of the correct shape
     fn try_from_value(value: serde_json::Value) -> Result<Self, Self::Error>;
+
+    /// Equivalent to [`Self::try_from_value`] but fails-fast if the valid is not of expected shape.
+    fn is_valid_value(value: &serde_json::Value) -> bool;
 }
 
 pub trait EntityTypeRef<'a>: Serialize + TypeRef {
@@ -255,6 +261,9 @@ where
     type Error: Context;
 
     fn try_from_entity(value: Entity) -> Option<Result<Self, Self::Error>>;
+
+    /// Equivalent to [`Self::try_from_value`] but fails-fast if the valid is not of expected shape.
+    fn is_valid_entity(value: &Entity) -> bool;
 }
 
 // These might be removed, but act as a marker trait.

--- a/libs/turbine/lib/turbine/src/types/data/boolean.rs
+++ b/libs/turbine/lib/turbine/src/types/data/boolean.rs
@@ -83,6 +83,10 @@ impl DataType for Boolean {
             Err(Report::new(BooleanError::NotABoolean(value)))
         }
     }
+
+    fn is_valid_value(value: &Value) -> bool {
+        value.is_boolean()
+    }
 }
 
 impl TypeRef for Boolean {

--- a/libs/turbine/lib/turbine/src/types/data/empty_list.rs
+++ b/libs/turbine/lib/turbine/src/types/data/empty_list.rs
@@ -68,6 +68,14 @@ impl DataType for EmptyList {
             Err(Report::new(EmptyListError::NotAnArray(value)))
         }
     }
+
+    fn is_valid_value(value: &Value) -> bool {
+        if let Value::Array(value) = value {
+            value.is_empty()
+        } else {
+            false
+        }
+    }
 }
 
 impl TypeRef for EmptyList {

--- a/libs/turbine/lib/turbine/src/types/data/null.rs
+++ b/libs/turbine/lib/turbine/src/types/data/null.rs
@@ -52,6 +52,10 @@ impl DataType for Null {
             Err(Report::new(NullError::NotNull(value)))
         }
     }
+
+    fn is_valid_value(value: &Value) -> bool {
+        value.is_null()
+    }
 }
 
 impl TypeRef for Null {

--- a/libs/turbine/lib/turbine/src/types/data/number.rs
+++ b/libs/turbine/lib/turbine/src/types/data/number.rs
@@ -77,6 +77,10 @@ impl DataType for Number {
             Err(Report::new(NumberError::NotANumber(value)))
         }
     }
+
+    fn is_valid_value(value: &Value) -> bool {
+        value.is_number()
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize)]

--- a/libs/turbine/lib/turbine/src/types/data/object.rs
+++ b/libs/turbine/lib/turbine/src/types/data/object.rs
@@ -84,6 +84,10 @@ impl DataType for Object {
             Err(Report::new(ObjectError::NotAnObject(value)))
         }
     }
+
+    fn is_valid_value(value: &Value) -> bool {
+        value.is_object()
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize)]

--- a/libs/turbine/lib/turbine/src/types/data/text.rs
+++ b/libs/turbine/lib/turbine/src/types/data/text.rs
@@ -84,6 +84,10 @@ impl DataType for Text {
             Err(Report::new(TextError::NotText(value)))
         }
     }
+
+    fn is_valid_value(value: &Value) -> bool {
+        value.is_string()
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]


### PR DESCRIPTION
This PR addresses an issue discovered through `https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/v/2`, which involves nested data. There were some discrepancies between the different parts of the generated code, specifically `Vec<T>` vs `Box<[T]>` and how `try_from_value` has been implemented.

This has been remedied through the use of `is_valid_value` (and `is_valid_entity`), which are two new trait methods that are now automatically implemented that will fail-fast (instead of fail-slow) and try to simply show a boolean: this is valid or invalid. This is in turn then used to select which variant to deserialize to.

The other problem was with a type with a particularly large amount of properties where the chunks remainder apparently is able contain 0 items if exactly at the boundary, which led to problems with `Report`