### PR TITLE
Allow `turbine` to be specified as a workspace dependency.

### DIFF
--- a/libs/turbine/bin/cli/src/cmd_lib.rs
+++ b/libs/turbine/bin/cli/src/cmd_lib.rs
@@ -197,6 +197,7 @@ fn call_remote(url: &Url, actor_id: Uuid) -> Result<Vec<AnyTypeRepr>, Error> {
 #[serde(tag = "type", content = "value", rename_all = "kebab-case")]
 pub enum Dependency {
     Path(PathBuf),
+    Workspace,
     Git {
         url: Url,
         rev: Option<String>,
@@ -222,6 +223,7 @@ impl From<Dependency> for skeletor::Dependency {
     fn from(value: Dependency) -> Self {
         match value {
             Dependency::Path(path) => Self::Path(path),
+            Dependency::Workspace => Self::Workspace,
             Dependency::Git {
                 url,
                 rev,
@@ -268,7 +270,7 @@ pub(crate) fn load_config(lib: Lib) -> core::result::Result<Config, figment::Err
         name,
         force,
         timings,
-        actor_id
+        actor_id,
     } = lib;
 
     let mut figment = Figment::new();
@@ -313,7 +315,10 @@ pub(crate) fn load_config(lib: Lib) -> core::result::Result<Config, figment::Err
         figment = figment.merge(("timings", figment::value::Value::from(timings)));
     }
     if let Some(actor_id) = actor_id {
-        figment = figment.merge(("actor_id", figment::value::Value::from(actor_id.to_string())))
+        figment = figment.merge((
+            "actor_id",
+            figment::value::Value::from(actor_id.to_string()),
+        ))
     }
 
     if let Some(profile) = Profile::from_env("TURBINE_PROFILE") {

--- a/libs/turbine/lib/skeletor/src/cargo.rs
+++ b/libs/turbine/lib/skeletor/src/cargo.rs
@@ -84,6 +84,7 @@ fn fetch_version(name: &str, timings: bool) -> Result<String, Error> {
 #[derive(Debug, Clone)]
 enum TurbineVersion {
     Path(String),
+    Workspace,
     Git {
         url: String,
         rev: Option<String>,
@@ -98,6 +99,7 @@ impl From<Dependency> for TurbineVersion {
     fn from(value: Dependency) -> Self {
         match value {
             Dependency::Path(path) => Self::Path(path.to_string_lossy().into_owned()),
+            Dependency::Workspace => Self::Workspace,
             Dependency::Git {
                 url,
                 rev,
@@ -120,6 +122,7 @@ impl Display for TurbineVersion {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Path(path) => f.write_fmt(format_args!(r##"{{ path = "{path}" }}"##)),
+            Self::Workspace => f.write_str("{ workspace = true }"),
             Self::Git {
                 url,
                 rev,

--- a/libs/turbine/lib/skeletor/src/lib.rs
+++ b/libs/turbine/lib/skeletor/src/lib.rs
@@ -54,6 +54,7 @@ pub enum Dependency {
         tag: Option<String>,
     },
     CratesIo,
+    Workspace,
 }
 
 impl Dependency {


### PR DESCRIPTION
Allows for 

```toml
[turbine]
type = "workspace"
```

in a `turbine.toml` (and friends), which will result in: `turbine = { workspace = true }` in the generated `Cargo.toml`