### PR TITLE
`turbine`: Add `draft` to Entity

### DIFF
--- a/libs/turbine/lib/turbine/src/entity.rs
+++ b/libs/turbine/lib/turbine/src/entity.rs
@@ -128,6 +128,7 @@ pub struct EntityMetadata {
     pub entity_type_id: VersionedUrl,
     pub provenance: ProvenanceMetadata,
     pub archived: bool,
+    pub draft: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
Adds the `draft` property to the `Entity` type, which has been added in HASH-Graph.